### PR TITLE
change rsa block cost to rsa private key

### DIFF
--- a/config/crd/bases/cert.dana.io_certificates.yaml
+++ b/config/crd/bases/cert.dana.io_certificates.yaml
@@ -95,6 +95,8 @@ spec:
                   name:
                     description: Name of the CertificateConfig.
                     type: string
+                required:
+                - name
                 type: object
               secretName:
                 description: SecretName is the name of the Kubernetes Secret where

--- a/internal/certhandler/decoder.go
+++ b/internal/certhandler/decoder.go
@@ -17,7 +17,7 @@ const (
 	errCannotCastToRSAPrivateKey = "cannot cast to RSA Private Key"
 
 	certificateBlockType = "CERTIFICATE"
-	rsaBlockType         = "PRIVATE KEY"
+	rsaBlockType         = "RSA PRIVATE KEY"
 )
 
 // TLSData represents TLS data containing a private key and certificate bytes.

--- a/internal/certhandler/decoder_test.go
+++ b/internal/certhandler/decoder_test.go
@@ -29,7 +29,7 @@ func Test_Decoder(t *testing.T) {
 			want: want{
 				tlsData: TLSData{
 					CertificateBytes: []uint8(`-----BEGIN CERTIFICATE-----`),
-					PrivateKeyBytes:  []uint8(`-----BEGIN PRIVATE KEY-----`),
+					PrivateKeyBytes:  []uint8(`-----BEGIN RSA PRIVATE KEY-----`),
 				},
 				err: nil,
 			},


### PR DESCRIPTION
This PR fixes a small bug in the parsing of the certificates. Now the header of the private key reads RSA PRIVATE KEY which is correct.