### PR TITLE
handle case of secret updates after certificate is valid

### DIFF
--- a/api/v1alpha1/certificate_types.go
+++ b/api/v1alpha1/certificate_types.go
@@ -51,6 +51,8 @@ type CertificateStatus struct {
 	Guid string `json:"guid,omitempty"`
 	// SignatureHashAlgorithm is the algorithm used to sign the certificate.
 	SignatureHashAlgorithm string `json:"signatureHashAlgorithm,omitempty"`
+	// SecretName is the name of the Kubernetes Secret where the extracted certificate is stored.
+	SecretName string `json:"secretName,omitempty"`
 }
 
 // CertificateData contains data for generating a Certificate.

--- a/config/crd/bases/cert.dana.io_certificates.yaml
+++ b/config/crd/bases/cert.dana.io_certificates.yaml
@@ -182,6 +182,10 @@ spec:
               issuer:
                 description: Issuer is the entity that issued the certificate.
                 type: string
+              secretName:
+                description: SecretName is the name of the Kubernetes Secret where
+                  the extracted certificate is stored.
+                type: string
               signatureHashAlgorithm:
                 description: SignatureHashAlgorithm is the algorithm used to sign
                   the certificate.

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ k8s.io/apiextensions-apiserver v0.29.4 h1:M7hbuHU/ckbibR7yPbe6DyNWgTFKNmZDbdZKD8
 k8s.io/apiextensions-apiserver v0.29.4/go.mod h1:TTDC9fB+0kHY2rogf5hgBR03KBKCwED+GHUsXGpR7SM=
 k8s.io/apimachinery v0.29.4 h1:RaFdJiDmuKs/8cm1M6Dh1Kvyh59YQFDcFuFTSmXes6Q=
 k8s.io/apimachinery v0.29.4/go.mod h1:i3FJVwhvSp/6n8Fl4K97PJEP8C+MM+aoDq4+ZJBf70Y=
+k8s.io/apimachinery v0.30.1 h1:ZQStsEfo4n65yAdlGTfP/uSHMQSoYzU/oeEbkmF7P2U=
+k8s.io/apimachinery v0.30.1/go.mod h1:iexa2somDaxdnj7bha06bhb43Zpa6eWH8N8dbqVjTUc=
 k8s.io/client-go v0.29.4 h1:79ytIedxVfyXV8rpH3jCBW0u+un0fxHDwX5F9K8dPR8=
 k8s.io/client-go v0.29.4/go.mod h1:kC1thZQ4zQWYwldsfI088BbK6RkxK+aF5ebV8y9Q4tk=
 k8s.io/component-base v0.29.4 h1:xeKzuuHI/1tjleu5jycDAcYbhAxeGHCQBZUY2eRIkOo=

--- a/internal/certhandler/secret_manager.go
+++ b/internal/certhandler/secret_manager.go
@@ -41,6 +41,7 @@ func CreateOrUpdateTLSSecret(ctx context.Context, kubeClient client.Client, secr
 			if createErr := kubeClient.Create(ctx, secret); createErr != nil {
 				return fmt.Errorf(errCreatingSecret, secret.Name, secret.Namespace, createErr)
 			}
+			return nil
 		} else {
 			return fmt.Errorf(errGettingSecret, secret.Name, secret.Namespace, err)
 		}

--- a/internal/controller/certificate_controller_helper.go
+++ b/internal/controller/certificate_controller_helper.go
@@ -117,6 +117,11 @@ func (r *CertificateReconciler) createOrUpdateTlsSecret(ctx context.Context, cer
 		return errorCondition(ConditionCreateOrUpdateTLSSecretFailed, err), fmt.Errorf(errCreateOrUpdateTlsSecret, err)
 	}
 
+	certificate.Status.SecretName = certificate.Spec.SecretName
+	if err = r.Status().Update(ctx, certificate); err != nil {
+		return errorCondition(ConditionUpdateStatusFailed, err), fmt.Errorf(errUpdateStatus, err)
+	}
+
 	return metav1.Condition{}, nil
 }
 


### PR DESCRIPTION
### Changes Made
* Added logic to handle the case where the secretName in the `Certificate` resource was changed when the certificate is valid.
* Updated the SetupWithManager function to watch for `Secret` delete events that have an owner reference of type `Certificate`.

### Testing
* Ran the existing test cases.
* Added a new test case for the bug fix.

### Issue Link
Fixes #10 